### PR TITLE
改进YPNavigationController

### DIFF
--- a/YPNavigationBarTransition-Example/YPNavigationController.h
+++ b/YPNavigationBarTransition-Example/YPNavigationController.h
@@ -12,6 +12,4 @@
 
 @interface YPNavigationController : UINavigationController
 
-@property (nonatomic, strong, readonly) YPNavigationBarTransitionCenter *transitionCenter;
-
 @end

--- a/YPNavigationBarTransition-Example/YPNavigationController.m
+++ b/YPNavigationBarTransition-Example/YPNavigationController.m
@@ -52,6 +52,14 @@ UIGestureRecognizerDelegate
     _transitionCenter.navigationController = self;
 }
 
+- (void) setDelegate:(id<UINavigationControllerDelegate>)delegate {
+    if (![_transitionCenter validateInnerNavigationDelegate:delegate]) {
+        _transitionCenter.navigationDelegate = delegate;
+    } else {
+        [super setDelegate:delegate];
+    }
+}
+
 #pragma mark - UIGestureRecognizerDelegate
 
 - (BOOL) gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {

--- a/YPNavigationBarTransition/YPNavigationBarTransitionCenter.h
+++ b/YPNavigationBarTransition/YPNavigationBarTransitionCenter.h
@@ -34,6 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) id<UINavigationControllerDelegate> navigationDelegate;
 @property (nonatomic, weak, nullable) UINavigationController *navigationController;
 
+- (BOOL) validateInnerNavigationDelegate:(nullable id)delegate;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/YPNavigationBarTransition/YPNavigationBarTransitionCenter.m
+++ b/YPNavigationBarTransition/YPNavigationBarTransitionCenter.m
@@ -92,6 +92,8 @@ BOOL YPTransitionNeedShowFakeBar(YPBarConfiguration *from,YPBarConfiguration *to
 }
 
 - (void) setNavigationDelegate:(id<UINavigationControllerDelegate>)navigationDelegate {
+    if ([self validateInnerNavigationDelegate:navigationDelegate]) return;
+    
     if (_navigationDelegate != navigationDelegate) {
         _navigationDelegate = navigationDelegate;
         
@@ -105,6 +107,10 @@ BOOL YPTransitionNeedShowFakeBar(YPBarConfiguration *from,YPBarConfiguration *to
 - (void) updateNavigationControllerDelegate {
     id<UINavigationControllerDelegate> delegate = (id<UINavigationControllerDelegate>)self.delegateProxy ?: self;
     _navigationController.delegate = delegate;
+}
+
+- (BOOL) validateInnerNavigationDelegate:(id)delegate {
+    return delegate && (delegate == self || delegate == self.delegateProxy);
 }
 
 #pragma mark - fakeBar


### PR DESCRIPTION
- transitionCenter 暴露接口判断是否是内部 navigation delegate
- YPNavigationController 不再需要暴露 transition center