### PR TITLE
修复右滑手势返回失效的bug

### DIFF
--- a/YPNavigationBarTransition/YPNavigationBarTransitionCenter.h
+++ b/YPNavigationBarTransition/YPNavigationBarTransitionCenter.h
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(NavigationBarTransitionCenter)
 @interface YPNavigationBarTransitionCenter : NSObject
 
+@property (nonatomic, assign) BOOL isTransitionNavigationBar;
+
 - (instancetype) init NS_UNAVAILABLE;
 + (instancetype) new NS_UNAVAILABLE;
 - (instancetype) initWithDefaultBarConfiguration:(id<YPNavigationBarConfigureStyle>)_default NS_DESIGNATED_INITIALIZER;

--- a/YPNavigationBarTransition/YPNavigationBarTransitionCenter.m
+++ b/YPNavigationBarTransition/YPNavigationBarTransitionCenter.m
@@ -220,7 +220,7 @@ static struct {
                                context:&ctx];
          }
          
-         if (self) self->_isTransitionNavigationBar = NO;
+         if (self) self.isTransitionNavigationBar = NO;
      }];
     
     void (^popInteractionEndBlock)(id<UIViewControllerTransitionCoordinatorContext>) =

--- a/YPNavigationBarTransition/YPNavigationController.m
+++ b/YPNavigationBarTransition/YPNavigationController.m
@@ -20,7 +20,6 @@ UINavigationControllerDelegate
 @property (nonatomic, strong) YPNavigationBarTransitionCenter *center;
 @property (nonatomic, weak, nullable) id<UINavigationControllerDelegate> navigationDelegate;
 @property (nonatomic, strong, nullable) YPNavigationControllerDelegateProxy *delegateProxy;
-@property (assign) BOOL isAnimation;
 
 @end
 
@@ -37,18 +36,7 @@ UINavigationControllerDelegate
     if (!self.delegate) {
         self.delegate = self;
     }
-    self.isAnimation = NO;
     self.interactivePopGestureRecognizer.delegate = self;
-}
-
-- (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
-    self.isAnimation = YES;
-    [super pushViewController:viewController animated:animated];
-}
-
-- (UIViewController *)popViewControllerAnimated:(BOOL)animated {
-    self.isAnimation = YES;
-    return [super popViewControllerAnimated:animated];
 }
 
 - (void) setDelegate:(id<UINavigationControllerDelegate>)delegate {
@@ -94,14 +82,13 @@ UINavigationControllerDelegate
     [_center navigationController:navigationController
            didShowViewController:viewController
                          animated:animated];
-    self.isAnimation = NO;
 }
 
 #pragma mark - UIGestureRecognizerDelegate
 
 - (BOOL) gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
     if (gestureRecognizer == self.interactivePopGestureRecognizer) {
-        if ([gestureRecognizer isKindOfClass:UIScreenEdgePanGestureRecognizer.class] && self.isAnimation) {
+        if ([gestureRecognizer isKindOfClass:UIScreenEdgePanGestureRecognizer.class] && _center.isTransitionNavigationBar) {
             return NO;
         }
         return self.viewControllers.count > 1;

--- a/YPNavigationBarTransition/internal/YPNavigationBarTransitionCenterInternal.h
+++ b/YPNavigationBarTransition/internal/YPNavigationBarTransitionCenterInternal.h
@@ -27,13 +27,7 @@ SOFTWARE.
 
 BOOL YPTransitionNeedShowFakeBar(YPBarConfiguration *from,YPBarConfiguration *to);
 
-@interface YPNavigationBarTransitionCenter ()
-<
-UIToolbarDelegate
->
-{
-    BOOL _isTransitionNavigationBar;
-}
+@interface YPNavigationBarTransitionCenter () <UIToolbarDelegate> 
 
 @property (nonatomic, strong) UIToolbar *fromViewControllerFakeBar;
 @property (nonatomic, strong) UIToolbar *toViewControllerFakeBar;

--- a/YPNavigationBarTransition/internal/YPNavigationControllerDelegateProxy.h
+++ b/YPNavigationBarTransition/internal/YPNavigationControllerDelegateProxy.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class YPNavigationController;
 @protocol UINavigationControllerDelegate;
 
@@ -17,5 +19,7 @@
                               interceptor:(YPNavigationController *)interceptor;
 - (instancetype) init NS_UNAVAILABLE;
 + (instancetype) new NS_UNAVAILABLE;
+
+NS_ASSUME_NONNULL_END
 
 @end


### PR DESCRIPTION
复现步骤：右滑一半再回去，手势失效了。

原因：`willShowViewController:`改变了`isAnimation`的状态，但是如果不走`didShowViewController:`不能重置`isAnimation`的状态，于是手势失效了。

解决方案：将`isTransitionNavigationBar`状态暴露出来，如果正在做动画，禁掉手势。


Fix #45     Revert #44 